### PR TITLE
added readPreference and readPreferenceTags to url and DialOptions.

### DIFF
--- a/session.go
+++ b/session.go
@@ -279,44 +279,81 @@ func ParseURL(url string) (*DialInfo, error) {
 	source := ""
 	setName := ""
 	poolLimit := 0
-	for k, v := range uinfo.options {
-		switch k {
+	readPreferenceMode := Primary
+	var readPreferenceTagSets []bson.D
+	for _, opt := range uinfo.options {
+		switch opt.key {
 		case "authSource":
-			source = v
+			source = opt.value
 		case "authMechanism":
-			mechanism = v
+			mechanism = opt.value
 		case "gssapiServiceName":
-			service = v
+			service = opt.value
 		case "replicaSet":
-			setName = v
+			setName = opt.value
 		case "maxPoolSize":
-			poolLimit, err = strconv.Atoi(v)
+			poolLimit, err = strconv.Atoi(opt.value)
 			if err != nil {
-				return nil, errors.New("bad value for maxPoolSize: " + v)
+				return nil, errors.New("bad value for maxPoolSize: " + opt.value)
 			}
+		case "readPreference":
+			switch opt.value {
+			case "nearest":
+				readPreferenceMode = Nearest
+			case "primary":
+				readPreferenceMode = Primary
+			case "primaryPreferred":
+				readPreferenceMode = PrimaryPreferred
+			case "secondary":
+				readPreferenceMode = Secondary
+			case "secondaryPreferred":
+				readPreferenceMode = SecondaryPreferred
+			default:
+				return nil, errors.New("bad value for readPreference: " + opt.value)
+			}
+		case "readPreferenceTags":
+			tags := strings.Split(opt.value, ",")
+			var doc bson.D
+			for _, tag := range tags {
+				kvp := strings.Split(tag, ":")
+				if len(kvp) != 2 {
+					return nil, errors.New("bad value for readPreferenceTags: " + opt.value)
+				}
+				doc = append(doc, bson.DocElem{Name: strings.TrimSpace(kvp[0]), Value: strings.TrimSpace(kvp[1])})
+			}
+			readPreferenceTagSets = append(readPreferenceTagSets, doc)
 		case "connect":
-			if v == "direct" {
+			if opt.value == "direct" {
 				direct = true
 				break
 			}
-			if v == "replicaSet" {
+			if opt.value == "replicaSet" {
 				break
 			}
 			fallthrough
 		default:
-			return nil, errors.New("unsupported connection URL option: " + k + "=" + v)
+			return nil, errors.New("unsupported connection URL option: " + opt.key + "=" + opt.value)
 		}
 	}
+
+	if readPreferenceMode == Primary && len(readPreferenceTagSets) > 0 {
+		return nil, errors.New("readPreferenceTagSet may not be specified when readPreference is primary")
+	}
+
 	info := DialInfo{
-		Addrs:          uinfo.addrs,
-		Direct:         direct,
-		Database:       uinfo.db,
-		Username:       uinfo.user,
-		Password:       uinfo.pass,
-		Mechanism:      mechanism,
-		Service:        service,
-		Source:         source,
-		PoolLimit:      poolLimit,
+		Addrs:     uinfo.addrs,
+		Direct:    direct,
+		Database:  uinfo.db,
+		Username:  uinfo.user,
+		Password:  uinfo.pass,
+		Mechanism: mechanism,
+		Service:   service,
+		Source:    source,
+		PoolLimit: poolLimit,
+		ReadPreference: &ReadPreference{
+			Mode:    readPreferenceMode,
+			TagSets: readPreferenceTagSets,
+		},
 		ReplicaSetName: setName,
 	}
 	return &info, nil
@@ -384,12 +421,25 @@ type DialInfo struct {
 	// See Session.SetPoolLimit for details.
 	PoolLimit int
 
+	// ReadPreference defines the manner in which servers are chosen. See
+	// Session.SetMode and Session.SelectServers.
+	ReadPreference *ReadPreference
+
 	// DialServer optionally specifies the dial function for establishing
 	// connections with the MongoDB servers.
 	DialServer func(addr *ServerAddr) (net.Conn, error)
 
 	// WARNING: This field is obsolete. See DialServer above.
 	Dial func(addr net.Addr) (net.Conn, error)
+}
+
+// ReadPreference defines the manner in which servers are chosen.
+type ReadPreference struct {
+	// Mode determines the consistency of results. See Session.SetMode.
+	Mode Mode
+
+	// TagSets indicates which servers are allowed to be used. See Session.SelectServers.
+	TagSets []bson.D
 }
 
 // mgo.v3: Drop DialInfo.Dial.
@@ -464,7 +514,14 @@ func DialWithInfo(info *DialInfo) (*Session, error) {
 		session.Close()
 		return nil, err
 	}
-	session.SetMode(Strong, true)
+
+	if info.ReadPreference != nil {
+		session.SelectServers(info.ReadPreference.TagSets...)
+		session.SetMode(info.ReadPreference.Mode, true)
+	} else {
+		session.SetMode(Strong, true)
+	}
+
 	return session, nil
 }
 
@@ -477,21 +534,26 @@ type urlInfo struct {
 	user    string
 	pass    string
 	db      string
-	options map[string]string
+	options []urlInfoOption
+}
+
+type urlInfoOption struct {
+	key   string
+	value string
 }
 
 func extractURL(s string) (*urlInfo, error) {
 	if strings.HasPrefix(s, "mongodb://") {
 		s = s[10:]
 	}
-	info := &urlInfo{options: make(map[string]string)}
+	info := &urlInfo{}
 	if c := strings.Index(s, "?"); c != -1 {
 		for _, pair := range strings.FieldsFunc(s[c+1:], isOptSep) {
 			l := strings.SplitN(pair, "=", 2)
 			if len(l) != 2 || l[0] == "" || l[1] == "" {
 				return nil, errors.New("connection option must be key=value: " + pair)
 			}
-			info.options[l[0]] = l[1]
+			info.options = append(info.options, urlInfoOption{key: l[0], value: l[1]})
 		}
 		s = s[:c]
 	}

--- a/session_test.go
+++ b/session_test.go
@@ -132,6 +132,73 @@ func (s *S) TestURLParsing(c *C) {
 	}
 }
 
+func (s *S) TestURLReadPreference(c *C) {
+	type test struct {
+		url  string
+		mode mgo.Mode
+	}
+
+	tests := []test{
+		{"localhost:40001?readPreference=primary", mgo.Primary},
+		{"localhost:40001?readPreference=primaryPreferred", mgo.PrimaryPreferred},
+		{"localhost:40001?readPreference=secondary", mgo.Secondary},
+		{"localhost:40001?readPreference=secondaryPreferred", mgo.SecondaryPreferred},
+		{"localhost:40001?readPreference=nearest", mgo.Nearest},
+	}
+
+	for _, test := range tests {
+		info, err := mgo.ParseURL(test.url)
+		c.Assert(err, IsNil)
+		c.Assert(info.ReadPreference, NotNil)
+		c.Assert(info.ReadPreference.Mode, Equals, test.mode)
+	}
+}
+
+func (s *S) TestURLInvalidReadPreference(c *C) {
+	urls := []string{
+		"localhost:40001?readPreference=foo",
+		"localhost:40001?readPreference=primarypreferred",
+	}
+	for _, url := range urls {
+		_, err := mgo.ParseURL(url)
+		c.Assert(err, NotNil)
+	}
+}
+
+func (s *S) TestURLReadPreferenceTags(c *C) {
+	type test struct {
+		url     string
+		tagSets []bson.D
+	}
+
+	tests := []test{
+		{"localhost:40001?readPreference=secondary&readPreferenceTags=dc:ny,rack:1", []bson.D{{{"dc", "ny"}, {"rack", "1"}}}},
+		{"localhost:40001?readPreference=secondary&readPreferenceTags= dc : ny ,  rack :   1 ", []bson.D{{{"dc", "ny"}, {"rack", "1"}}}},
+		{"localhost:40001?readPreference=secondary&readPreferenceTags=dc:ny", []bson.D{{{"dc", "ny"}}}},
+		{"localhost:40001?readPreference=secondary&readPreferenceTags=rack:1&readPreferenceTags=dc:ny", []bson.D{{{"rack", "1"}}, {{"dc", "ny"}}}},
+	}
+
+	for _, test := range tests {
+		info, err := mgo.ParseURL(test.url)
+		c.Assert(err, IsNil)
+		c.Assert(info.ReadPreference, NotNil)
+		c.Assert(info.ReadPreference.TagSets, DeepEquals, test.tagSets)
+	}
+}
+
+func (s *S) TestURLInvalidReadPreferenceTags(c *C) {
+	urls := []string{
+		"localhost:40001?readPreference=secondary&readPreferenceTags=dc",
+		"localhost:40001?readPreference=secondary&readPreferenceTags=dc:ny,rack",
+		"localhost:40001?readPreference=secondary&readPreferenceTags=dc,rack",
+		"localhost:40001?readPreference=primary&readPreferenceTags=dc:ny",
+	}
+	for _, url := range urls {
+		_, err := mgo.ParseURL(url)
+		c.Assert(err, NotNil)
+	}
+}
+
 func (s *S) TestInsertFindOne(c *C) {
 	session, err := mgo.Dial("localhost:40001")
 	c.Assert(err, IsNil)
@@ -4159,11 +4226,11 @@ func (s *S) TestBypassValidation(c *C) {
 
 func (s *S) TestVersionAtLeast(c *C) {
 	tests := [][][]int{
-		{{3,2,1}, {3,2,0}},
-		{{3,2,1}, {3,2}},
-		{{3,2,1}, {2,5,5,5}},
-		{{3,2,1}, {2,5,5}},
-		{{3,2,1}, {2,5}},
+		{{3, 2, 1}, {3, 2, 0}},
+		{{3, 2, 1}, {3, 2}},
+		{{3, 2, 1}, {2, 5, 5, 5}},
+		{{3, 2, 1}, {2, 5, 5}},
+		{{3, 2, 1}, {2, 5}},
 	}
 	for _, pair := range tests {
 		bi := mgo.BuildInfo{VersionArray: pair[0]}


### PR DESCRIPTION
This also changes how url parsing works. It allows for multiple keys of the same name. This is only used for readPreferenceTags and the same behavior still exists for other keys (last one wins).
