### PR TITLE
fixing issue with getMore not using getMore command when available.

### DIFF
--- a/session.go
+++ b/session.go
@@ -2369,6 +2369,11 @@ func (c *Collection) NewIter(session *Session, firstBatch []bson.Raw, cursorId i
 		timeout: -1,
 		err:     err,
 	}
+
+	if socket.ServerInfo().MaxWireVersion >= 4 && c.FullName != "admin.$cmd" {
+		iter.findCmd = true
+	}
+
 	iter.gotReply.L = &iter.m
 	for _, doc := range firstBatch {
 		iter.docData.Push(doc.Data)


### PR DESCRIPTION
Basically, when we create a new iterator, if the server version is adequate, we'll set the iter.findCmd to true. iter.findCmd is really a misnomer, but it's what kicks off the use of the getMore command as opposed to OP_GETMORE. 

This fixes the issue for aggregate, and should fix the issue for listCollections, listIndexes, etc... for anything that returns a cursor.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/10gen/mgo/3)
<!-- Reviewable:end -->
