### PR TITLE
Add Count64.

### DIFF
--- a/session.go
+++ b/session.go
@@ -4032,8 +4032,7 @@ type countCmd struct {
 	Skip  int32 ",omitempty"
 }
 
-// Count returns the total number of documents in the result set.
-func (q *Query) Count() (n int, err error) {
+func (q *Query) count() (n int64, err error) {
 	q.m.Lock()
 	session := q.session
 	op := q.op
@@ -4051,14 +4050,31 @@ func (q *Query) Count() (n int, err error) {
 	if query == nil {
 		query = bson.D{}
 	}
-	result := struct{ N int }{}
+	result := struct{ N int64 }{}
 	err = session.DB(dbname).Run(countCmd{cname, query, limit, op.skip}, &result)
 	return result.N, err
 }
 
+// Count returns the total number of documents in the result set.
+func (q *Query) Count() (n int, err error) {
+	n, err = q.count()
+	return int(n), err
+}
+
 // Count returns the total number of documents in the collection.
 func (c *Collection) Count() (n int, err error) {
-	return c.Find(nil).Count()
+	n, err = c.Find(nil).count()
+	return int(n), err
+}
+
+// Count64 returns the total number of documents in the result set.
+func (q *Query) Count64() (n int64, err error) {
+	return q.count()
+}
+
+// Count64 returns the total number of documents in the collection.
+func (c *Collection) Count64() (n int64, err error) {
+	return c.Find(nil).count()
 }
 
 type distinctCmd struct {

--- a/session_test.go
+++ b/session_test.go
@@ -1194,6 +1194,10 @@ func (s *S) TestCountCollection(c *C) {
 	n, err := coll.Count()
 	c.Assert(err, IsNil)
 	c.Assert(n, Equals, 3)
+
+	n, err := coll.Count64()
+	c.Assert(err, IsNil)
+	c.Assert(n, Equals, int64(3))
 }
 
 func (s *S) TestCountQuery(c *C) {
@@ -1212,6 +1216,10 @@ func (s *S) TestCountQuery(c *C) {
 	n, err := coll.Find(M{"n": M{"$gt": 40}}).Count()
 	c.Assert(err, IsNil)
 	c.Assert(n, Equals, 2)
+
+	n64, err := coll.Find(M{"n": M{"$gt": 40}}).Count64()
+	c.Assert(err, IsNil)
+	c.Assert(n, Equals, int64(2))
 }
 
 func (s *S) TestCountQuerySorted(c *C) {
@@ -1230,6 +1238,10 @@ func (s *S) TestCountQuerySorted(c *C) {
 	n, err := coll.Find(M{"n": M{"$gt": 40}}).Sort("n").Count()
 	c.Assert(err, IsNil)
 	c.Assert(n, Equals, 2)
+
+	n64, err := coll.Find(M{"n": M{"$gt": 40}}).Sort("n").Count()
+	c.Assert(err, IsNil)
+	c.Assert(n, Equals, int64(2))
 }
 
 func (s *S) TestCountSkipLimit(c *C) {
@@ -1249,9 +1261,17 @@ func (s *S) TestCountSkipLimit(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(n, Equals, 3)
 
+	n64, err := coll.Find(nil).Skip(1).Limit(3).Count64()
+	c.Assert(err, IsNil)
+	c.Assert(n, Equals, int64(3))
+
 	n, err = coll.Find(nil).Skip(1).Limit(5).Count()
 	c.Assert(err, IsNil)
 	c.Assert(n, Equals, 4)
+
+	n64, err = coll.Find(nil).Skip(1).Limit(5).Count()
+	c.Assert(err, IsNil)
+	c.Assert(n, Equals, int64(4))
 }
 
 func (s *S) TestQueryExplain(c *C) {


### PR DESCRIPTION
This change adds `Count64` to deal with large (>31 bit) counts on platforms where `int` is only 32 bits large.