### PR TITLE
MGO-134 Add helper method to return a readable server address.

### DIFF
--- a/session.go
+++ b/session.go
@@ -631,6 +631,17 @@ func (s *Session) LiveServers() (addrs []string) {
 	return addrs
 }
 
+// ReadableServer returns a server address which is suitable for reading
+// according to the current session.
+func (s *Session) ReadableServer() (string, error) {
+	socket, err := s.acquireSocket(true)
+	if err != nil {
+		return "", err
+	}
+	defer socket.Release()
+	return socket.server.Addr, nil
+}
+
 // DB returns a value representing the named database. If name
 // is empty, the database name provided in the dialed URL is
 // used instead. If that is also empty, "test" is used as a

--- a/session_test.go
+++ b/session_test.go
@@ -221,7 +221,7 @@ func (s *S) TestReadableServer(c *C) {
 		c.Fatalf("secondary_address should be in %v, not: %v", valid_addresses, secondary_address)
 	}
 
-	c.Assert(err, primary_address, Not(Equals), secondary_address)
+	c.Assert(primary_address, Not(Equals), secondary_address)
 }
 
 func (s *S) TestInsertFindOne(c *C) {

--- a/session_test.go
+++ b/session_test.go
@@ -199,6 +199,31 @@ func (s *S) TestURLInvalidReadPreferenceTags(c *C) {
 	}
 }
 
+func (s *S) TestReadableServer(c *C) {
+	session, err := mgo.Dial("localhost:40001,localhost:40002")
+	c.Assert(err, IsNil)
+	defer session.Close()
+
+	session.SetMode(mgo.Primary, true)
+	primary_address, err := session.ReadableServer()
+	c.Assert(err, IsNil)
+
+	valid_addresses := []string{"localhost:40001", "localhost:40002"}
+	if primary_address != valid_addresses[0] && primary_address != valid_addresses[1] {
+		c.Fatalf("primary_address should be in %v, not: %v", valid_addresses, primary_address)
+	}
+
+	session.SetMode(mgo.Secondary, true)
+	secondary_address, err := session.ReadableServer()
+	c.Assert(err, IsNil)
+
+	if secondary_address != valid_addresses[0] && secondary_address != valid_addresses[1] {
+		c.Fatalf("secondary_address should be in %v, not: %v", valid_addresses, secondary_address)
+	}
+
+	c.Assert(err, primary_address, Not(Equals), secondary_address)
+}
+
 func (s *S) TestInsertFindOne(c *C) {
 	session, err := mgo.Dial("localhost:40001")
 	c.Assert(err, IsNil)

--- a/session_test.go
+++ b/session_test.go
@@ -200,28 +200,23 @@ func (s *S) TestURLInvalidReadPreferenceTags(c *C) {
 }
 
 func (s *S) TestReadableServer(c *C) {
-	session, err := mgo.Dial("localhost:40001,localhost:40002")
+	session, err := mgo.Dial("localhost:40011,localhost:40012,localhost:40013")
 	c.Assert(err, IsNil)
 	defer session.Close()
 
 	session.SetMode(mgo.Primary, true)
 	primary_address, err := session.ReadableServer()
 	c.Assert(err, IsNil)
-
-	valid_addresses := []string{"localhost:40001", "localhost:40002"}
-	if primary_address != valid_addresses[0] && primary_address != valid_addresses[1] {
-		c.Fatalf("primary_address should be in %v, not: %v", valid_addresses, primary_address)
-	}
+	c.Assert(primary_address, Equals, "localhost:40011")
 
 	session.SetMode(mgo.Secondary, true)
 	secondary_address, err := session.ReadableServer()
 	c.Assert(err, IsNil)
 
+	valid_addresses := []string{"localhost:40012", "localhost:40013"}
 	if secondary_address != valid_addresses[0] && secondary_address != valid_addresses[1] {
 		c.Fatalf("secondary_address should be in %v, not: %v", valid_addresses, secondary_address)
 	}
-
-	c.Assert(primary_address, Not(Equals), secondary_address)
 }
 
 func (s *S) TestInsertFindOne(c *C) {


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/MGO-134

This changes allows a program to first create a session to an entire cluster possibly with read preference and tags and then create a subsequent session connected directly to a single readable server from the first session.