### PR TITLE
Don't opimistically request a nonce until it's needed.

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -205,12 +205,12 @@ func (socket *mongoSocket) loginClassic(cred Credential) error {
 	// Note that this only works properly because this function is
 	// synchronous, which means the nonce won't get reset while we're
 	// using it and any other login requests will block waiting for a
-	// new nonce provided in the defer call below.
+	// new nonce.
+	socket.resetNonce();
 	nonce, err := socket.getNonce()
 	if err != nil {
 		return err
 	}
-	defer socket.resetNonce()
 
 	psum := md5.New()
 	psum.Write([]byte(cred.Username + ":mongo:" + cred.Password))

--- a/socket.go
+++ b/socket.go
@@ -190,7 +190,6 @@ func newSocket(server *mongoServer, conn net.Conn, timeout time.Duration) *mongo
 	}
 	stats.socketsAlive(+1)
 	debugf("Socket %p to %s: initialized", socket, socket.addr)
-	socket.resetNonce()
 	go socket.readLoop()
 	return socket
 }


### PR DESCRIPTION
Currently, mgo sends a {getnonce:1} request to mongod/mongos immediately upon connection regardless of the auth mechanism ultimately being used.
https://github.com/10gen/mgo/blob/9a2573d4ae52a2bf9f5b7900a50e2f8bcceeb774/socket.go#L193

Through MongoDB 3.6, this is mostly harmless as the allocated nonce eventually expires when the connection goes away, however with MongoDB >= 3.8 the MONGODB-CR authentication mechanism has been removed, and ideally the {getnonce:1} command would go with it.

In the interest of BC with existing tools using mgo, the getnonce command will be retained for the foreseeable future as a dummy command so that mgo based tools won't break, however we'd like to remove it eventually, and hope that by updating mgo we can do so.