### PR TITLE
MGO-161 Add modern server versions to test suite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,13 +17,23 @@ env:
         - GO=1.4.1 MONGODB=x86_64-3.2.3-nojournal
         - GO=1.5.3 MONGODB=x86_64-3.0.9
         - GO=1.6   MONGODB=x86_64-3.0.9
+        - GO=1.6   MONGODB=x86_64-3.2.21 URL=MONGO
+        - GO=1.6   MONGODB=x86_64-3.4.18 URL=MONGO
+        - GO=1.6   MONGODB=x86_64-3.6.8 URL=MONGO
+        - GO=1.6   MONGODB=x86_64-4.0.4 URL=MONGO
 
 install:
     - eval "$(gimme $GO)"
 
-    - wget $BUCKET/mongodb-linux-$MONGODB.tgz
+    - |
+      if [ "$URL" == "MONGO" ]; then
+        wget http://fastdl.mongodb.org/linux/mongodb-linux-${MONGODB}.tgz
+      else
+        wget $BUCKET/mongodb-linux-$MONGODB.tgz
+      fi
     - tar xzvf mongodb-linux-$MONGODB.tgz
     - export PATH=$PWD/mongodb-linux-$MONGODB/bin:$PATH
+    - mongod --version
 
     - wget $BUCKET/daemontools.tar.gz
     - tar xzvf daemontools.tar.gz

--- a/session_test.go
+++ b/session_test.go
@@ -294,7 +294,7 @@ func (s *S) TestInsertFindOneNil(c *C) {
 
 	coll := session.DB("mydb").C("mycoll")
 	err = coll.Find(nil).One(nil)
-	c.Assert(err, ErrorMatches, "unauthorized.*|not authorized.*")
+	c.Assert(err, ErrorMatches, UnauthorizedErrorRegex)
 }
 
 func (s *S) TestInsertFindOneMap(c *C) {
@@ -4126,7 +4126,7 @@ func (s *S) TestFindIterDoneErr(c *C) {
 	ok := iter.Next(&result)
 	c.Assert(iter.Done(), Equals, true)
 	c.Assert(ok, Equals, false)
-	c.Assert(iter.Err(), ErrorMatches, "unauthorized.*|not authorized.*")
+	c.Assert(iter.Err(), ErrorMatches, UnauthorizedErrorRegex)
 }
 
 func (s *S) TestFindIterDoneNotFound(c *C) {


### PR DESCRIPTION
TODO:
- [x] *Fixed*: On 4.0, lots of tests fail with: 
  ```
  session_test.go:4129:
      c.Assert(iter.Err(), ErrorMatches, "unauthorized.*|not authorized.*")
  ... error string = "command find requires authentication"
  ... regex string = "unauthorized.*|not authorized.*"
  ```
- [ ] On 3.4, TestCollationQueries fails with: 
  ```
  c.Assert(err, IsNil)
  ... value *mgo.QueryError = &mgo.QueryError{Code:67, Message:"Invalid index specification { name: \"text_number_1\", ns: \"mydb.mycoll\", key: { text_number: 1 }, collation: { locale: \"en\", numericOrdering: true } }; cannot create an index with the 'collation' option and v=1", Assertion:false} ("Invalid index specification { name: \"text_number_1\", ns: \"mydb.mycoll\", key: { text_number: 1 }, collation: { locale: \"en\", numericOrdering: true } }; cannot create an index with the 'collation' option and v=1")
  ```
- [ ] On 4.0, TestModeMonotonicWriteOnIteration sometimes fails with:
  ```
  [LOG] 0.14717 Socket 0xc8204a8b60 to localhost:40012: received document: bson.M{"cursor":bson.M{"firstBatch":[]interface {}{bson.M{"_id":"[\xe4\xae\xc0@\xc5Lq\x89$\xdf^", "n":40}}, "id":0, "ns":"mydb.mycoll1"}, "ok":1, "operationTime":6621609491798425602, "$gleStats":bson.M{"lastOpTime":0, "electionId":"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"}, "lastCommittedOpTime":6621609491798425601, "$configServerState":bson.M{"opTime":bson.M{"t":1, "ts":6621609466028621827}}, "$clusterTime":bson.M{"clusterTime":6621609491798425608, "signature":bson.M{"hash":[]uint8{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}, "keyId":0}}}
  [LOG] 0.14731 Iter 0xc8200c1a40 received reply document 1/1 (cursor=0)
  [LOG] 0.14736 Iter 0xc8200c1a40 document unmarshaled: &mgo_test.M{"_id":"[\xe4\xae\xc0@\xc5Lq\x89$\xdf^", "n":40}
  [LOG] 0.14737 Iter 0xc8200c1a40 exhausted with cursor=0
  cluster_test.go:355:
      c.Assert(i, Equals, len(ns))
  ... obtained int = 1
  ... expected int = 7
  ``` 
  See https://travis-ci.org/10gen/mgo/jobs/452602673#L1288.
