### PR TITLE
MGO-155 NoCursorTimeout is not respected for findCmd

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ before_script:
 
 script:
     - (cd bson && go test -check.v)
-    - go test -check.v -fast
+    - go test -check.v -fast -cursor-timeout
     - (cd txn && go test -check.v)
 
 # vim:sw=4:ts=4:et

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ before_script:
 
 script:
     - (cd bson && go test -check.v)
-    - if [["$MONGODB" > "x86_64-3.0.1" ]]; then go test -check.v -fast -cursor-timeout; else go test -check.v -fast; fi
+    - if [[ "$MONGODB" > "x86_64-3.0.1" ]]; then go test -check.v -fast -cursor-timeout; else go test -check.v -fast; fi
     - (cd txn && go test -check.v)
 
 # vim:sw=4:ts=4:et

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ before_script:
 
 script:
     - (cd bson && go test -check.v)
-    - if [[ "$MONGODB" > "x86_64-3.0.1" ]]; then go test -check.v -fast -cursor-timeout; else go test -check.v -fast; fi
+    - go test -check.v -fast -cursor-timeout
     - (cd txn && go test -check.v)
 
 # vim:sw=4:ts=4:et

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ before_script:
 
 script:
     - (cd bson && go test -check.v)
-    - go test -check.v -fast -cursor-timeout
+    - if [["$MONGODB" > "x86_64-3.0.1" ]]; then go test -check.v -fast -cursor-timeout; else go test -check.v -fast; fi
     - (cd txn && go test -check.v)
 
 # vim:sw=4:ts=4:et

--- a/session.go
+++ b/session.go
@@ -3291,19 +3291,22 @@ func prepareFindOp(socket *mongoSocket, op *queryOp, limit int32) bool {
 	}
 
 	find := findCmd{
-		Collection:  op.collection[nameDot+1:],
-		Filter:      op.query,
-		Projection:  op.selector,
-		Sort:        op.options.OrderBy,
-		Skip:        op.skip,
-		Limit:       limit,
-		MaxTimeMS:   op.options.MaxTimeMS,
-		MaxScan:     op.options.MaxScan,
-		Hint:        op.options.Hint,
-		Comment:     op.options.Comment,
-		Snapshot:    op.options.Snapshot,
-		OplogReplay: op.flags&flagLogReplay != 0,
-		Collation:   op.options.Collation,
+		Collection:      op.collection[nameDot+1:],
+		Filter:          op.query,
+		Projection:      op.selector,
+		Sort:            op.options.OrderBy,
+		Skip:            op.skip,
+		Limit:           limit,
+		MaxTimeMS:       op.options.MaxTimeMS,
+		MaxScan:         op.options.MaxScan,
+		Hint:            op.options.Hint,
+		Comment:         op.options.Comment,
+		Snapshot:        op.options.Snapshot,
+		Tailable:        op.flags&flagTailable != 0,
+		AwaitData:       op.flags&flagAwaitData != 0,
+		OplogReplay:     op.flags&flagLogReplay != 0,
+		NoCursorTimeout: op.flags&flagNoCursorTimeout != 0,
+		Collation:       op.options.Collation,
 	}
 	if op.limit < 0 {
 		find.BatchSize = -op.limit

--- a/session_test.go
+++ b/session_test.go
@@ -1704,6 +1704,10 @@ func (s *S) TestFindIterCursorTimeout(c *C) {
 		c.Skip("-cursor-timeout")
 	}
 
+	if !s.versionAtLeast(3, 0, 2) {
+		c.Skip("cursorTimeoutMillis parameter requires 3.0.2+")
+	}
+
 	session, err := mgo.Dial("localhost:40001")
 	c.Assert(err, IsNil)
 	defer session.Close()
@@ -1752,6 +1756,11 @@ func (s *S) TestFindIterCursorNoTimeout(c *C) {
 	if !*cursorTimeout {
 		c.Skip("-cursor-timeout")
 	}
+
+	if !s.versionAtLeast(3, 0, 2) {
+		c.Skip("cursorTimeoutMillis parameter requires 3.0.2+")
+	}
+
 	session, err := mgo.Dial("localhost:40001")
 	c.Assert(err, IsNil)
 	defer session.Close()

--- a/session_test.go
+++ b/session_test.go
@@ -1697,7 +1697,7 @@ func (s *S) TestFindIterLimit(c *C) {
 var cursorTimeout = flag.Bool("cursor-timeout", false, "Enable cursor timeout tests")
 
 // This error message varies based on server version.
-var cursorTimeoutRegex = "invalid cursor|cursor id .* not found"
+var cursorTimeoutRegex = "invalid cursor|Cursor not found, cursor id: .*|cursor id .* not found"
 
 func (s *S) TestFindIterCursorTimeout(c *C) {
 	if !*cursorTimeout {

--- a/session_test.go
+++ b/session_test.go
@@ -1700,9 +1700,17 @@ func (s *S) TestFindIterCursorTimeout(c *C) {
 	if !*cursorTimeout {
 		c.Skip("-cursor-timeout")
 	}
+
 	session, err := mgo.Dial("localhost:40001")
 	c.Assert(err, IsNil)
 	defer session.Close()
+
+	// Set a short cursor timeout on the server.
+	err = session.Run(bson.D{{"setParameter", 1}, {"cursorTimeoutMillis", int64(10)}}, nil)
+	c.Assert(err, IsNil)
+
+	// Set timeout back to normal when this test completes.
+	defer session.Run(bson.D{{"setParameter", 1}, {"cursorTimeoutMillis", int64(6 * 10 * 1000)}}, nil)
 
 	type Doc struct {
 		Id int "_id"
@@ -1710,7 +1718,7 @@ func (s *S) TestFindIterCursorTimeout(c *C) {
 
 	coll := session.DB("test").C("test")
 	coll.Remove(nil)
-	for i := 0; i < 100; i++ {
+	for i := 0; i < 10; i++ {
 		err = coll.Insert(Doc{i})
 		c.Assert(err, IsNil)
 	}
@@ -1722,20 +1730,19 @@ func (s *S) TestFindIterCursorTimeout(c *C) {
 		c.Fatalf("iterator failed to return any documents")
 	}
 
-	for i := 10; i > 0; i-- {
-		c.Logf("Sleeping... %d minutes to go...", i)
-		time.Sleep(1*time.Minute + 2*time.Second)
-	}
+	// Give the cursor an opportunity to time out. While we only set timeout to 10ms, in practice
+	// it seems to take a bit longer for the server to actually kill the cursor.
+	time.Sleep(5 * time.Second)
 
 	// Drain any existing documents that were fetched.
 	if !iter.Next(&doc) {
 		c.Fatalf("iterator with timed out cursor failed to return previously cached document")
 	}
 	if iter.Next(&doc) {
-		c.Fatalf("timed out cursor returned document")
+		c.Fatalf("timed out cursor returned document, expected error")
 	}
 
-	c.Assert(iter.Err(), Equals, mgo.ErrCursor)
+	c.Assert(iter.Err(), ErrorMatches, "cursor id .* not found")
 }
 
 func (s *S) TestFindIterCursorNoTimeout(c *C) {
@@ -1746,6 +1753,13 @@ func (s *S) TestFindIterCursorNoTimeout(c *C) {
 	c.Assert(err, IsNil)
 	defer session.Close()
 
+	// Set a short cursor timeout on the server.
+	err = session.Run(bson.D{{"setParameter", 1}, {"cursorTimeoutMillis", int64(10)}}, nil)
+	c.Assert(err, IsNil)
+
+	// Set timeout back to normal when this test completes.
+	defer session.Run(bson.D{{"setParameter", 1}, {"cursorTimeoutMillis", int64(6 * 10 * 1000)}}, nil)
+
 	session.SetCursorTimeout(0)
 
 	type Doc struct {
@@ -1754,7 +1768,7 @@ func (s *S) TestFindIterCursorNoTimeout(c *C) {
 
 	coll := session.DB("test").C("test")
 	coll.Remove(nil)
-	for i := 0; i < 100; i++ {
+	for i := 0; i < 10; i++ {
 		err = coll.Insert(Doc{i})
 		c.Assert(err, IsNil)
 	}
@@ -1766,23 +1780,22 @@ func (s *S) TestFindIterCursorNoTimeout(c *C) {
 		c.Fatalf("iterator failed to return any documents")
 	}
 
-	for i := 10; i > 0; i-- {
-		c.Logf("Sleeping... %d minutes to go...", i)
-		time.Sleep(1*time.Minute + 2*time.Second)
-	}
+	// Sleep until cursorTimeoutMillis has passed. While we only set timeout to 10ms, in practice
+	// it seems to take a bit longer for the server to actually kill cursors.
+	time.Sleep(5 * time.Second)
 
 	// Drain any existing documents that were fetched.
 	if !iter.Next(&doc) {
 		c.Fatalf("iterator failed to return previously cached document")
 	}
-	for i := 1; i < 100; i++ {
+	for i := 0; i < 8; i++ {
 		if !iter.Next(&doc) {
 			c.Errorf("iterator failed on iteration %d", i)
 			break
 		}
 	}
 	if iter.Next(&doc) {
-		c.Error("iterator returned more than 100 documents")
+		c.Error("iterator returned more than 10 documents")
 	}
 
 	c.Assert(iter.Err(), IsNil)

--- a/session_test.go
+++ b/session_test.go
@@ -1694,7 +1694,7 @@ func (s *S) TestFindIterLimit(c *C) {
 	c.Assert(stats.SocketsInUse, Equals, 0)
 }
 
-var cursorTimeout = flag.Bool("cursor-timeout", false, "Enable cursor timeout test")
+var cursorTimeout = flag.Bool("cursor-timeout", false, "Enable cursor timeout tests")
 
 func (s *S) TestFindIterCursorTimeout(c *C) {
 	if !*cursorTimeout {
@@ -1736,6 +1736,56 @@ func (s *S) TestFindIterCursorTimeout(c *C) {
 	}
 
 	c.Assert(iter.Err(), Equals, mgo.ErrCursor)
+}
+
+func (s *S) TestFindIterCursorNoTimeout(c *C) {
+	if !*cursorTimeout {
+		c.Skip("-cursor-timeout")
+	}
+	session, err := mgo.Dial("localhost:40001")
+	c.Assert(err, IsNil)
+	defer session.Close()
+
+	session.SetCursorTimeout(0)
+
+	type Doc struct {
+		Id int "_id"
+	}
+
+	coll := session.DB("test").C("test")
+	coll.Remove(nil)
+	for i := 0; i < 100; i++ {
+		err = coll.Insert(Doc{i})
+		c.Assert(err, IsNil)
+	}
+
+	session.SetBatch(1)
+	iter := coll.Find(nil).Iter()
+	var doc Doc
+	if !iter.Next(&doc) {
+		c.Fatalf("iterator failed to return any documents")
+	}
+
+	for i := 10; i > 0; i-- {
+		c.Logf("Sleeping... %d minutes to go...", i)
+		time.Sleep(1*time.Minute + 2*time.Second)
+	}
+
+	// Drain any existing documents that were fetched.
+	if !iter.Next(&doc) {
+		c.Fatalf("iterator failed to return previously cached document")
+	}
+	for i := 1; i < 100; i++ {
+		if !iter.Next(&doc) {
+			c.Errorf("iterator failed on iteration %d", i)
+			break
+		}
+	}
+	if iter.Next(&doc) {
+		c.Error("iterator returned more than 100 documents")
+	}
+
+	c.Assert(iter.Err(), IsNil)
 }
 
 func (s *S) TestTooManyItemsLimitBug(c *C) {

--- a/session_test.go
+++ b/session_test.go
@@ -1696,6 +1696,9 @@ func (s *S) TestFindIterLimit(c *C) {
 
 var cursorTimeout = flag.Bool("cursor-timeout", false, "Enable cursor timeout tests")
 
+// This error message varies based on server version.
+var cursorTimeoutRegex = "invalid cursor|cursor id .* not found"
+
 func (s *S) TestFindIterCursorTimeout(c *C) {
 	if !*cursorTimeout {
 		c.Skip("-cursor-timeout")
@@ -1742,7 +1745,7 @@ func (s *S) TestFindIterCursorTimeout(c *C) {
 		c.Fatalf("timed out cursor returned document, expected error")
 	}
 
-	c.Assert(iter.Err(), ErrorMatches, "cursor id .* not found")
+	c.Assert(iter.Err(), ErrorMatches, cursorTimeoutRegex)
 }
 
 func (s *S) TestFindIterCursorNoTimeout(c *C) {


### PR DESCRIPTION
Building on @BenLubar's PR to ensure cursor timeout is correctly sent in find commands, this improves the cursor timeout tests to only require a short sleep rather than the 10 minute default by manually setting the server timeout to 10ms.
we now always pass the -cursor-timeout flag when testing on travis, but the tests will be skipped regardless if we're on < MongoDB 3.0.2.